### PR TITLE
Update VRS spec: PS import or export of depth or stencil causes coarse shading and less common feature intersection

### DIFF
--- a/d3d/VariableRateShading.md
+++ b/d3d/VariableRateShading.md
@@ -604,6 +604,12 @@ For SV_InnerCoverage:
 ### Coverage
 When conservative rasterization is used, the coverage semantic contains full masks for fine pixels that are covered and 0 for fine pixels that are not covered.
 
+### An intersection: coarse shading, conservative rasterization, and centroid
+According to the [conservative rasterization spec](https://microsoft.github.io/DirectX-Specs/d3d/ConservativeRasterization.html), 
+> centroid interpolation modes produce results identical to the corresponding non-centroid interpolation mode
+
+The above concept still holds when using coarse pixel shading. When coarse shading with conservative rasterization on Tier 2 or coarse-shading-compatible Tier 1 platforms, centroid interpolation is simply treated as center.
+
 ## Bundles
 Variable-rate shading APIs can be called on bundles.
 

--- a/d3d/VariableRateShading.md
+++ b/d3d/VariableRateShading.md
@@ -334,6 +334,12 @@ A pixel shader fails compilation if it inputs SV_ShadingRate and also uses sampl
 ## Depth and Stencil
 When coarse pixel shading is used, depth and stencil and coverage are always computed and emitted at the full sample resolution.
 
+### Import and Export of Depth and Stencil
+If a pixel shader imports or exports depth or stencil (for example, by SV_Depth, SV_StencilRef, or SV_Position.z) then shading occurs at fine rate. That is to say, coarse shading is disabled.
+ 
+> ### Remark: Workaround for reading depth and stencil
+> To work around coarse-shading-disablement when reading depth or stencil, applications may choose to read them instead by passing them in as an interpolated value to the pixel shader.
+
 ## Using the Shading Rate Requested
 For all tiers, it is expected that if a shading rate is requested, and it is supported on the device-and-MSAA-level-combination together with the relevent rendering feature areas, then that is the shading rate delivered by the hardware.
 


### PR DESCRIPTION
This spec update clarifies that 
* import or export of depth or stencil in the pixel shader causes coarse shading, and
* use of coarse shading, conservative rasterization, and centroid interpolation together produces a result equivalent to non-centroid (i.e., center)