### PR TITLE
Fix table creation

### DIFF
--- a/d3d/D3D12_FeatureLevel12_2.md
+++ b/d3d/D3D12_FeatureLevel12_2.md
@@ -56,6 +56,7 @@ If a device is feature level 12_2, it has
 |MaxGPUVirtualAddressBitsPerProcess                                       | 40
 
 Additionally, it has the following flags set
+
 | Feature                                                                 | 12_2 proposed value 
 |:-                                                                       |-                   
 |WaveOps	                                                              | TRUE


### PR DESCRIPTION
A table of additional flags was not created in the built html at Feature Level 12_2.