### PR TITLE
Update MeshShader.md

### DIFF
--- a/d3d/MeshShader.md
+++ b/d3d/MeshShader.md
@@ -58,9 +58,9 @@ Contents
     - [Streamout](#streamout)
 
 * [Examples](#examples)
-    - [Example 1: Passthrough](#example-1:-passthrough)
-    - [Example 2: Culling](#example-2:-culling)
-    - [Example 3: Amplification](#example-3:-amplification)
+    - [Example 1: Passthrough](#example-1-passthrough)
+    - [Example 2: Culling](#example-2-culling)
+    - [Example 3: Amplification](#example-3-amplification)
 
 Intro
 =====


### PR DESCRIPTION
Fix the 3 examples link error due to the unnecessary colon in the link.