### PR TITLE
Add external links to the DXC wiki for shader models/features spec'd there

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ These specs are presented with different interfaces at two different URLs:
     * [Video Protected Resource Support](d3d/D3D12_Video_ProtectedResourceSupport.md)
 
 * HLSL
+    * [Shader Model 6.0](https://github.com/microsoft/DirectXShaderCompiler/wiki/Shader-Model-6.0)
+    * [Shader Model 6.1](https://github.com/microsoft/DirectXShaderCompiler/wiki/Shader-Model-6.1)
+    * [Shader Model 6.2](https://github.com/microsoft/DirectXShaderCompiler/wiki/Shader-Model-6.2)
+    * [Shader Model 6.3](https://github.com/microsoft/DirectXShaderCompiler/wiki/Shader-Model-6.3)
+    * [Shader Model 6.4](https://github.com/microsoft/DirectXShaderCompiler/wiki/Shader-Model-6.4)
     * [Shader Model 6.5](d3d/HLSL_ShaderModel6_5.md)
+    * [SV_Barycentrics](https://github.com/microsoft/DirectXShaderCompiler/wiki/SV_Barycentrics)
+    * [SV_ViewID](https://github.com/microsoft/DirectXShaderCompiler/wiki/SV_ViewID)
 
 * Developer Features
     * [Device Removed Extended Data](d3d/DeviceRemovedExtendedData.md)


### PR DESCRIPTION
I debated whether I should tag them as coming from external (I had † annotations on them at first) but removed them ecause I assumed that GitHub would tag them as external for me. It doesn't... but maybe this is still fine?