### PR TITLE
Update HLSL_ShaderModel6_5.md

### DIFF
--- a/d3d/HLSL_ShaderModel6_5.md
+++ b/d3d/HLSL_ShaderModel6_5.md
@@ -224,11 +224,11 @@ output = WaveMultiPrefixSum(value, mask);
 
 |laneID   | 7     | 6     | 5     | 4     | 3     | 2     | 1 | 0
 |:-       |-      |-      |-      |-      |-      |-      |-  |-
-| mask.x  | 0xe0  | 0xe0  | 0xe0  | 0x14  | 0x09  | 0x14  | - | 0x0b
+| mask.x  | 0xe0  | 0xe0  | 0xe0  | 0x14  | 0x09  | 0x02  | - | 0x14
 | value   | 5     | 4     | 1     | -2    | 3     | 0     | - | 6
 | output  | 5     | 1     | 0     | 0     | 6     | 0     | - | 0
 
-Note how subset with `mask.x == 0x0b` refers to lane 1,
+Note how subset with `mask.x == 0x02` refers to lane 1,
 which is either inactive or is a helper lane.
 This doesn't affect the result since bits in the mask
 corresponding to inactive or helper lanes are ignored.


### PR DESCRIPTION
Hi,

Before my change, it says "Note how subset with mask.x == 0x0b refers to lane 1, which is either inactive or is a helper lane". Since mask 0x0b is for lane 0 and it's Prefix, lane 1 shouldn't be considered anyway. I think set the second bit of mask in lane 2 will reduce possibility of confusion.
It also mentioned "The groups are assumed to be non-intersecting". However, mask 0xb and 0x9 have overlaps in the example, so I suggest to update 0xb to 0x2.
BTW, do you really want the groups to be non-intersecting? I think there are quite some scenarios in real world needs to reuse same lane in different groups.

Thanks,
Mengbo