### PR TITLE
Add clarification around shading rate resource state, SupportsPerVertexShadingRateWithMultipleViewports

### DIFF
--- a/d3d/VariableRateShading.md
+++ b/d3d/VariableRateShading.md
@@ -153,7 +153,10 @@ Features for each tier are described in greater detail below the table.
   * Indicates whether 2X4, 4X2, and 4X4 coarse pixel sizes are supported for single sampled rendering, and whether coarse pixel size 2X4 is supported for 2xMSAA.
 * SupportsPerVertexShadingRateWithMultipleViewports
   * Boolean type
-  * Indicates whether more than one viewport can be used with the per-vertex (also referred to as ‘per-primitive’) shading rate
+  * Indicates that an application can both 
+     * use more than one viewport, and
+     * use the per-vertex (also referred to as ‘per-primitive’) shading rate
+  * at the same time. If this cap is FALSE, and per-vertex shading rates are used, then only one viewport can be used at a time. The cap does *not* pertain to the idea of using different shading rates for different viewports. Variable rate shading does not expose a way to use different shading rates for different viewports.
 * VariableRateShadingSumCombinerSupported
   * Boolean type
   * Indicates whether the SUM combiner can be used. This cap is pertaining to variable rate shading Tier 2.

--- a/d3d/VariableRateShading.md
+++ b/d3d/VariableRateShading.md
@@ -247,7 +247,11 @@ Each byte of the screen space image corresponds to a value of the D3D12_SHADING_
 #### Resource state
 A resource needs to be transitioned into a read-only state when used as a screen-space image. A read-only state, D3D12_RESOURCE_STATE_SHADING_RATE_SOURCE, is defined for this purpose. 
 
-The image resource is transitioned out of that state to become writable again.
+Validation of shading rate image resource state occurs at Draw time. In other words, resources need to be in SHADING_RATE_SOURCE state when a Draw is executed that has the shading rate image set.
+
+When a resource is passed as an argument to RSSetShadingRateImage, it can be in SHADING_RATE_SOURCE state or some other state. The resource doesn't have to be in SHADING_RATE_SOURCE state until some Draw is executed that has the resource set as a shading rate image.
+
+An image resource is transitioned out of SHADING_RATE_SOURCE to become writable again.
 
 #### Setting the image
 The screen-space image for specifying shader rate is set on the command list.


### PR DESCRIPTION
This change 
- adds detail around when validation of SHADING_RATE_SOURCE state take place. It's at Draw-time, not earlier
- clarifies that the SupportsPerVertexShadingRateWithMultipleViewports cap doesn't indicate a per-viewport shading rate.