### PR TITLE
Fix RWTexture2DMSArray operator signatures

### DIFF
--- a/d3d/HLSL_SM_6_7_Advanced_Texture_Ops.md
+++ b/d3d/HLSL_SM_6_7_Advanced_Texture_Ops.md
@@ -255,8 +255,8 @@ The second references the location in the provided sample index.
 ```c++
 R RWTexture2DMS::Operator[](uint2 pos);
 R RWTexture2DMS::sample.Operator[][](uint sampleIndex, uint2 pos);
-R RWTexture2DMSArray::Operator[](uint2 pos);
-R RWTexture2DMSArray::sample.Operator[][](uint sampleIndex, uint2 pos);
+R RWTexture2DMSArray::Operator[](uint3 pos);
+R RWTexture2DMSArray::sample.Operator[][](uint sampleIndex, uint3 pos);
 ```
 
 Support for writable MSAA textures is determined by


### PR DESCRIPTION
The `pos` parameters must be of type `uint3` to include the array index.