### PR TITLE
Clarify WaveMultiPrefixSum() Illustration

### DIFF
--- a/d3d/HLSL_ShaderModel6_5.md
+++ b/d3d/HLSL_ShaderModel6_5.md
@@ -231,7 +231,9 @@ output = WaveMultiPrefixSum(value, mask);
 Note how subset with `mask.x == 0x0b` refers to lane 1,
 which is either inactive or is a helper lane.
 This doesn't affect the result since bits in the mask
-corresponding to inactive or helper lanes are ignored.
+corresponding to inactive or helper lanes are ignored
+(lane 0's `mask.x` effectively becomes `0x09`, so there
+is no intersecting subset of lanes).
 
 ## Example usage
 


### PR DESCRIPTION
Explicitly call out that even though the mask bits for lane 0 and lane 3 seem to create an intersecting subset of lanes, the fact that lane 1 is inactive means that it's bit is ignored in the mask (even when determining if there are intersections) so the masks for lanes 0 and 3 are actually the same.