### PR TITLE
Update HLSL_SM_6_6_Int64_and_Float_Atomics.md

### DIFF
--- a/d3d/HLSL_SM_6_6_Int64_and_Float_Atomics.md
+++ b/d3d/HLSL_SM_6_6_Int64_and_Float_Atomics.md
@@ -556,7 +556,7 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
 `AtomicInt64OnTypedResourceSupported` is a boolean that specifies
 whether typed resource 64-bit integer atomics are supported.
 `AtomicInt64OnGroupSharedSupported` is a boolean that specifies
-whether typed resource 64-bit integer atomics are supported.
+whether 64-bit integer atomics are supported on `groupshared` variables.
 `AtomicInt64OnDescriptorHeapResourceSupported` is a boolean that specifies
 whether 64-bit integer atomics on resources
 in descriptor heaps are supported.


### PR DESCRIPTION
Fixed the copy-paste error from the line above. AtomicInt64OnGroupSharedSupported has nothing to do with Typed Resources.