### PR TITLE
Revised the blending precision spec for 999E5

### DIFF
--- a/d3d/archive/D3D11_3_FunctionalSpec.htm
+++ b/d3d/archive/D3D11_3_FunctionalSpec.htm
@@ -14738,7 +14738,7 @@ e.g. with the format R8G8_UNORM, the components B,A entering the blending hardwa
 <p>Note that this clamping must be done on a per-rendertarget basis,
 so if one render target is a float type and another is UNORM type, the shader values and blend factor must be
 float range for the float render target Blend, and clamped to 0..1 for the UNORM render target Blend.</p>
-<p>An exception is float16, float11 or float10 RenderTargets, where it is permitted
+<p>An exception is float16, float11, float10 or R9G9B9E5 RenderTargets, where it is permitted
 for implementations to not clamp data going into the blend.  So it is required that blend operations on these formats to be
 be done with at least equal precision/range as the output format but an implementation can choose to perform blending with
 precision/range (up to float32).</p>


### PR DESCRIPTION
Previously the blending precision spec does not take into account 999E5 for clamping of input. As 999E5 is another form of float, it should.