### PR TITLE
Update VariableRateShading.md (fix misleading sentence)

### DIFF
--- a/d3d/VariableRateShading.md
+++ b/d3d/VariableRateShading.md
@@ -612,7 +612,7 @@ The following table indicates how many coverage bits are needed for each combina
 As indicated in the above table, it is not possible to use coarse pixels to write to more than 16 samples at a time using the variable rate shading feature exposed through Direct3D12. This restriction is brought about by Direct3D12’s constraints regarding which MSAA levels are allowed with which coarse pixel size (see table under section "New model").
 
 ### Ordering and Format of Bits in the Coverage Mask
-Bits of the coverage mask adhere to a well-defined order. The mask consists of the of coverages from pixels from left-to-right, then top-to-bottom (column-major) order. Coverage bits are the low-order bits of the coverage semantic and are densely packed together. 
+Bits of the coverage mask adhere to a well-defined order. The mask consists of the of coverages from pixels from right-to-left, then bottom-to-top (row-major) order. Coverage bits are the low-order bits of the coverage semantic and are densely packed together. 
 
 The table below shows the coverage mask format for supported combinations of coarse pixel size and MSAA level.
 


### PR DESCRIPTION
Tried to fix the following sentence to make it match the tables below (for some interpretations).  It may actually be better to delete the entire sentence:

> The mask consists of the of coverages from pixels from left-to-right, then top-to-bottom (column-major) order.

First, it's definitely row-major order, not column-major. Each *row* of fine pixels are contiguous in the sample mask, not each *column*.

Second, when evaluating an attribute with centroid evaluation, the definition states to use the "first covered sample". The "first" means the lowest-order bit that is set.  I interpret that to mean that the "order" of the sample mask should be read as lowest-order to highest-order.  Given the tables in this diagram, I would say the order is "right-to-left, then bottom-to-top (row-major)", hence this change.