### PR TITLE
Removing mention that GetClockCalibration requires SetStablePowerState and issues a warning if not used

### DIFF
--- a/d3d/CountersAndQueries.md
+++ b/d3d/CountersAndQueries.md
@@ -398,9 +398,6 @@ This API is intended for development time use only. Therefore it is only
 allowed when the D3D12 SDK layers are present on the machine. The API
 fails with E_FAIL if the D3D12 SDK layers are not present.
 
-The debug layer will issue a warning if the GetClockCalibration API is
-used without SetStablePowerState being called first.
-
 This API is implemented with new kernel-mode DDIs which are described
 separately.
 


### PR DESCRIPTION
The Debug Layer doesn't seem to be actually issuing a warning in this case, and it doesn't seem that the intent is that it should be required. See Discord discussion on the DirectX 12 channel here : https://discord.com/channels/590611987420020747/590965902564917258/1276363117022023740