### PR TITLE
Remove nonworking code from Dynamic Resources spec

### DIFF
--- a/d3d/HLSL_SM_6_6_DynamicResources.md
+++ b/d3d/HLSL_SM_6_6_DynamicResources.md
@@ -54,11 +54,16 @@ CBV, SRV, or UAV resource variable or function call argument.
 `SamplerDescriptorHeap[index]` must be used to assign a local or global
 SamplerState or SamplerComparisonState variable or function call argument.
 
-Here's an example usage:
+This example demonstrates how resources of different types can come from the heaps:
 
 ```C++
-Texture2D<float4> myTexture = ResourceDescriptorHeap[texIdx];
-float4 result = myTexture.Sample(SamplerDescriptorHeap[sampIdx], coord);
+Texture2D<float3> myTexture = ResourceDescriptorHeap[texIdx];
+SamplerState samp = SamplerDescriptorHeap[sampIdx];
+float3 color = myTexture.Sample(samp, coord);
+
+Texture2D<float4> myShadowMap = ResourceDescriptorHeap[texIdx+1];
+SamplerComparisonState compSamp = SamplerDescriptorHeap[sampIdx+1];
+float shadow = myShadowMap.SampleCmp(compSamp, shadowCoord, cmpVal);
 ```
 
 The object type returned by these indexing operations
@@ -208,6 +213,7 @@ set in the blob part `DFCC_FeatureInfo` (FourCC `SFI0`).
 
 Version|Date|Description
 -|-|-
+1.00|31 Jul 2024|Corrected malfunctioning sample, added a cmp example
 1.00|20 Apr 2021|Minor Edits for Publication
 0.7|2020-10-07|Added Descriptor and Data Volatility
 0.6|2020-09-25|Note for local root signature, update feature flags


### PR DESCRIPTION
Passing a value from a resource array to an intrinsic doesn't work in DXC. That will be addressed at some point, but in the meantime, we don't want the leading people to use nonfunctional code.

This updates the spec text to avoid the broken usage and makes the example more illustrative of how the resource heaps work.

See https://github.com/microsoft/DirectXShaderCompiler/issues/4520