### PR TITLE
(minor typo) Fix heading "Changes to subobject types" in SerializedRootSignatures.md

### DIFF
--- a/d3d/SerializedRootSignatures.md
+++ b/d3d/SerializedRootSignatures.md
@@ -147,5 +147,4 @@ public:
         _COM_Outptr_  void **ppvRootSignature) = 0;
     
 };
-
 ```

--- a/d3d/SerializedRootSignatures.md
+++ b/d3d/SerializedRootSignatures.md
@@ -52,7 +52,7 @@ To keep things consitent for the runtime and the compiler the new subobject type
 
 ## Runtime support for the new subobject type
 
-###Changes to subobject types
+### Changes to subobject types
 ```cpp
 typedef enum D3D12_PIPELINE_STATE_SUBOBJECT_TYPE
 {
@@ -147,4 +147,5 @@ public:
         _COM_Outptr_  void **ppvRootSignature) = 0;
     
 };
+
 ```


### PR DESCRIPTION
Missing space prevents heading from being shown correctly.