### PR TITLE
docs: fix common English typos

### DIFF
--- a/d3d/D3D12PIXMarkers.md
+++ b/d3d/D3D12PIXMarkers.md
@@ -17,7 +17,7 @@ v0.01 12 Mar 2026
 
 # Summary
 
-As of 2025, [PIXEvents](https://github.com/microsoft/PixEvents) provides APIs to instrument your game, labeling regions of CPU or GPU work and marking important occurences. Common APIs include `PixBeginEvent`, `PixEndEvent`, and `PixSetMarker` which internally call `ID3D12GraphicsCommandList::BeginEvent`, `ID3D12CommandQueue::BeginEvent`, `ID3D12GraphicsCommandList::EndEvent` `ID3D12CommandQueue::EndEvent`, `ID3D12GraphicsCommandList::SetMarker` and `ID3D12CommandQueue::SetMarker` depending on the context.
+As of 2025, [PIXEvents](https://github.com/microsoft/PixEvents) provides APIs to instrument your game, labeling regions of CPU or GPU work and marking important occurrences. Common APIs include `PixBeginEvent`, `PixEndEvent`, and `PixSetMarker` which internally call `ID3D12GraphicsCommandList::BeginEvent`, `ID3D12CommandQueue::BeginEvent`, `ID3D12GraphicsCommandList::EndEvent` `ID3D12CommandQueue::EndEvent`, `ID3D12GraphicsCommandList::SetMarker` and `ID3D12CommandQueue::SetMarker` depending on the context.
 
 The limitation of these APIs is that they operate only at the runtime level and do not propagate to the driver. As a result, these markers are absent in [DirectX dump files](D3D12GpuDumps.md), making it difficult to trace the marker hierarchy that led to a TDR or device error.
 

--- a/d3d/D3D12_Video_Encoding_LowerResolution_2Pass.md
+++ b/d3d/D3D12_Video_Encoding_LowerResolution_2Pass.md
@@ -495,7 +495,7 @@ Please note:
 3. [Frame 1] Once `RFn` is ready, the app is notified that that frame is completed (including slice/tile data + frame stats).
     - Note that [D3D12_Video_Encoding_SubregionNotification](D3D12_Video_Encoding_SubregionNotification.md) can be used to get slices/tiles earlier in the `CPU Consumer` timeline.
 4. [Future frames] Once the next input frame is available, same process as for `Frame 1` explained above happens. The app will be able to track a parallel DPB array of textures / texture array of downsampled reconstructed pictured that mirrors the full resolution DPB to pass to the subsequent `EFn` calls. The downscaled DPB textures are tracked/evicted along their full resolution DPB texture counterpart.
-    - `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the begining of the `VPIn` command (and the subsequent delay of the tasks depending on it).
+    - `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the beginning of the `VPIn` command (and the subsequent delay of the tasks depending on it).
 
 ![VPBlit VPblitEncodeTimeline](./images/D3D12_Video_Encoding_LowerResolution_2Pass/VPblitEncodeTimeline.png)
 
@@ -570,7 +570,7 @@ Please note:
     - Note that [D3D12_Video_Encoding_SubregionNotification](D3D12_Video_Encoding_SubregionNotification.md) can be used to get slices/tiles earlier in the `CPU Consumer` timeline.
 5. [Future frames] Once the next input frame is available, same process as for `Frame 1` explained above happens, but there is an additional dependency to `EFn`, the downscaled reference picture from the previous frame (if used as reference and placed in the full resolution DPB). As a result, there's an additional waiting dependency on `EFn` with `VPR n-1`. The app will be able to track a parallel DPB array of textures / texture array of downsampled reconstructed pictured that mirrors the full resolution DPB to pass to the subsequent `EFn` calls. The downscaled DPB textures are tracked/evicted along their full resolution DPB texture counterpart.
     - Please note that `VPR2` takes longer to execute than `VPR1` in the diagram to show how such delays would add latency between `EFn` executions.
-    - Similarly, `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the begining of the `VPIn` command (and the subsequent delay of the tasks depending on it).
+    - Similarly, `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the beginning of the `VPIn` command (and the subsequent delay of the tasks depending on it).
 
 ![VPBlit VPblitEncodeTimeline_external](./images/D3D12_Video_Encoding_LowerResolution_2Pass/VPblitEncodeTimeline_external.png)
 
@@ -596,6 +596,6 @@ Please note:
     - For future frames, the app must externally downscale the full resolution (2nd pass) output reconstructed picture to provide the lower resolution DPB.
 6. [Future frames] Once the next input frame is available, same process as for `Frame 1` explained above happens, but there is an additional dependency to `EFn`, the downscaled reference picture from the previous frame (if used as reference and placed in the full resolution DPB). As a result, there's an additional waiting dependency on `EFn` with `VPR n-1`. The app will be able to track a parallel DPB array of textures / texture array of downsampled reconstructed pictured that mirrors the full resolution DPB to pass to the subsequent `EFn` calls. The downscaled DPB textures are tracked/evicted along their full resolution DPB texture counterpart.
     - Please note that `VPR2` takes longer to execute than `VPR1` in the diagram to show how such delays would add latency between `EFn` executions.
-    - Similarly, `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the begining of the `VPIn` command (and the subsequent delay of the tasks depending on it).
+    - Similarly, `Input Ready N` is assumed to have no dependencies with previous encode outputs (e.g stats) in this diagram, with the frames flowing in from another pipeline upstream. Any additional delays in `Input Ready N` would also delay the beginning of the `VPIn` command (and the subsequent delay of the tasks depending on it).
 
 ![VPBlit VPblitEncodeTimeline_external](./images/D3D12_Video_Encoding_LowerResolution_2Pass/VPblitEncodeTimeline_external_skipping.png)

--- a/d3d/ShaderCompilerPlugin.md
+++ b/d3d/ShaderCompilerPlugin.md
@@ -2443,7 +2443,7 @@ On return, a pointer the compiler interface specified by riid.
 Database Files:
 
 - If a specified file does not exist, it is created.  If it exists, it is opened for modification.
-- Value types may be stored in seperate databases.  For example, PDBs may be stored in a seperate database file than object code.
+- Value types may be stored in separate databases.  For example, PDBs may be stored in a separate database file than object code.
 
 #### Method ID3D12CompilerFactory::CreateCompiler
 


### PR DESCRIPTION
## What

Fixes common English typos in documentation files.

## Changes

- `d3d/ShaderCompilerPlugin.md` — `seperate` → `separate` (2 occurrences)
- `d3d/D3D12PIXMarkers.md` — `occurence` → `occurrence` (1 occurrence)
- `d3d/D3D12_Video_Encoding_LowerResolution_2Pass.md` — `begining` → `beginning` (3 occurrences)

## Why

These are unambiguous English misspellings that slipped past review. The corrections are the widely-accepted English spellings:
- `recieve` / `recieved` / `recieving` → `receive` / `received` / `receiving` (common "ie"/"ei" reversal)
- `seperate` / `seperated` / `seperately` → `separate` / `separated` / `separately`
- `occured` / `occuring` / `occurence` → `occurred` / `occurring` / `occurrence`
- `begining` → `beginning`
- `succesful` / `succesfully` → `successful` / `successfully`
- `neccessary` → `necessary`
- `accomodate` → `accommodate`
- `overriden` → `overridden`
- `compatable` → `compatible`
- `cancelation` → `cancellation`
- `Pallete` → `Palette`

## Testing

- Documentation-only changes. No code affected.
- Each change is a literal one-word replacement. Diff is trivial to review.
